### PR TITLE
Azure is typesetting sp-timestamp from String to Object. 

### DIFF
--- a/HttpTriggerJS1/ingest_api/routes/alarm_ingest.js
+++ b/HttpTriggerJS1/ingest_api/routes/alarm_ingest.js
@@ -14,7 +14,8 @@ exports.ingest = function (req, context) {
     // Azure bug strips quotes from timestamps making them appear to be an object when they have a dot before millisec
         var datetime_properties = [
             'occurred_at',
-            'context.timestamp'
+            'context.timestamp',
+            'sp-timestamp'
         ];
         _.forEach(datetime_properties, function (datetime_property) {
             var date_value = _.get(body, datetime_property);


### PR DESCRIPTION
Need it to reset to string prior to validation. This then allows ISO format for sp-timestamp.